### PR TITLE
minion keys for master work around for vagrant start

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,6 +15,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       salt.master_config = "saltstack/etc/master"
       salt.master_key = "saltstack/keys/master_minion.pem"
       salt.master_pub = "saltstack/keys/master_minion.pub"
+      salt.minion_key = "saltstack/keys/master_minion.pem"
+      salt.minion_pub = "saltstack/keys/master_minion.pub"
       salt.seed_master = {
                           "minion1" => "saltstack/keys/minion1.pub",
                           "minion2" => "saltstack/keys/minion2.pub"


### PR DESCRIPTION
Fixes #10  Vagrant will not start becasue it wants a public and private
key for the master.  This is a work around and the salt provisioner
should be fixed so that when no_minion = true in Vagrantfile, what tests if minion
keys are present is ignored.
