### PR TITLE
changes install type from "stable" to "git" to workaround salt issue #25042

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,12 +23,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
                           "minion2" => "saltstack/keys/minion2.pub"
                          }
 
-      salt.install_type = "stable"
+      salt.install_type = "git v2016.3.0"
       salt.install_master = true
       salt.no_minion = true
       salt.verbose = true
       salt.colorize = true
-      salt.bootstrap_options = "-P -c /tmp"
+      salt.bootstrap_options = "-c /tmp"
     end
   end
 
@@ -41,10 +41,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       salt.minion_config = "saltstack/etc/minion1"
       salt.minion_key = "saltstack/keys/minion1.pem"
       salt.minion_pub = "saltstack/keys/minion1.pub"
-      salt.install_type = "stable"
+      salt.install_type = "git v2016.3.0"
       salt.verbose = true
       salt.colorize = true
-      salt.bootstrap_options = "-P -c /tmp"
+      salt.bootstrap_options = "-c /tmp"
     end
   end
 
@@ -61,10 +61,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       salt.minion_config = "saltstack/etc/minion2"
       salt.minion_key = "saltstack/keys/minion2.pem"
       salt.minion_pub = "saltstack/keys/minion2.pub"
-      salt.install_type = "stable"
+      salt.install_type = "git v2016.3.0"
       salt.verbose = true
       salt.colorize = true
-      salt.bootstrap_options = "-P -c /tmp"
+      salt.bootstrap_options = "-c /tmp"
     end
   end
 


### PR DESCRIPTION
https://github.com/saltstack/salt/issues/25042#issuecomment-222512976

@UtahDave Some users are now having issues using this with the get started guide (see issue above), which I was able to confirm. I tried upgrading the box, upgrading virtualbox and vagrant, and nothing did the trick.

After testing, changing the vagrantfile to install from git fixed the issue, I tested these changes with the latest vagrant/virtualbox and it worked great. The minions respond immediately.

Do you mind merging this until the referenced issue is fixed?

I also removed the -P flag from the bootstrap options in this PR since it is no longer needed.
