### PR TITLE
bah to using chef images =D

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,7 +56,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # The following line can be uncommented to use Centos
     # instead of Ubuntu.
     # Comment out the above line as well
-    #minion_config.vm.box = "chef/centos-6.5"
+    #minion_config.vm.box = "bento/centos-7.2"
     minion_config.vm.host_name = 'saltminion2.local'
     minion_config.vm.network "private_network", ip: "192.168.50.12"
 


### PR DESCRIPTION
I was able to go through the demo with the centos 7 images, except the part of install cowsay. The default centos image does not have the EPEL repo enabled.
