### PR TITLE
Update to bento/ubuntu-16.04

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,7 +9,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       vb.memory = 1024
   end
   config.vm.define :master do |master_config|
-    master_config.vm.box = "ubuntu/trusty64"
+    master_config.vm.box = "bento/ubuntu-16.04"
     master_config.vm.host_name = 'saltmaster.local'
     master_config.vm.network "private_network", ip: "192.168.50.10"
     master_config.vm.synced_folder "saltstack/salt/", "/srv/salt"
@@ -36,7 +36,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.define :minion1 do |minion_config|
-    minion_config.vm.box = "ubuntu/trusty64"
+    minion_config.vm.box = "bento/ubuntu-16.04"
     minion_config.vm.host_name = 'saltminion1.local'
     minion_config.vm.network "private_network", ip: "192.168.50.11"
 
@@ -52,7 +52,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.define :minion2 do |minion_config|
-    minion_config.vm.box = "ubuntu/trusty64"
+    minion_config.vm.box = "bento/ubuntu-16.04"
     # The following line can be uncommented to use Centos
     # instead of Ubuntu.
     # Comment out the above line as well


### PR DESCRIPTION
This PR proposes to update the VMs from Ubuntu 14.04 (EOL) to the current LTS, Ubuntu 16.04.

In addition it switches to the bento repo because it is the one recommended by Vagrant (see https://www.vagrantup.com/docs/boxes.html). For me the most important part is Ubuntu 16.04, which repo is less important.