### PR TITLE
Forcing the vagrant cloud server url to https://vagrantcloud.com

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,6 +2,7 @@
 # vi: set ft=ruby :
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|


### PR DESCRIPTION
Instead of atlas.hashicorp.com

Without this patch, you'll get this error:

```
cyprien.diot@techCyp:~/salt-vagrant-demo$ vagrant up
Bringing machine 'master' up with 'virtualbox' provider...
Bringing machine 'minion1' up with 'virtualbox' provider...
Bringing machine 'minion2' up with 'virtualbox' provider...
==> master: Box 'bento/ubuntu-16.04' could not be found. Attempting to find and install...
    master: Box Provider: virtualbox
    master: Box Version: >= 0
The box 'bento/ubuntu-16.04' could not be found or
could not be accessed in the remote catalog. If this is a private
box on HashiCorp's Atlas, please verify you're logged in via
`vagrant login`. Also, please double-check the name. The expanded
URL and error message are shown below:

URL: ["https://atlas.hashicorp.com/bento/ubuntu-16.04"]
Error: The requested URL returned error: 404 Not Found
```