### PR TITLE
Bumping Ubuntu version from 16 to 18 (to fix formula bug)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  os = "bento/ubuntu-16.04"
+  os = "bento/ubuntu-18.04"
   net_ip = "192.168.50"
 
   config.vm.define :master, primary: true do |master_config|


### PR DESCRIPTION
Adding formulas via git doesn't appear to work with the currently used "bento/ubuntu-16.04" version of Ubuntu