### PR TITLE
upgrade to using Python3 Salt Master & Minions

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,7 +37,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       salt.no_minion = true
       salt.verbose = true
       salt.colorize = true
-      salt.bootstrap_options = "-P -c /tmp"
+      salt.bootstrap_options = "-P -c /tmp -x python3"
     end
   end
 
@@ -64,7 +64,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         salt.install_type = "stable"
         salt.verbose = true
         salt.colorize = true
-        salt.bootstrap_options = "-P -c /tmp"
+        salt.bootstrap_options = "-P -c /tmp -x python3"
       end
     end
   end


### PR DESCRIPTION
With Python 2 being EOL, let's move to Python 3 versions of Salt.